### PR TITLE
[ADD] missing note field in the fiscal position form

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -62,6 +62,11 @@
                             </field>
                         </group>
                         </page>
+                        <page name="note" string="Remark">
+                            <group>
+                                <field name="note" />
+                            </group>
+                        </page>
                     </notebook>
                     </sheet>
                 </form>


### PR DESCRIPTION
Missing where to enter a fiscal position note that it can be shown on the [invoice report](https://github.com/odoo/odoo/blob/9.0/addons/account/views/report_invoice.xml#L148).
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

On invoice it can be printed, but there was no way to enter it.
